### PR TITLE
Updated script for a new ICV structure

### DIFF
--- a/build_update.sh
+++ b/build_update.sh
@@ -3,9 +3,9 @@
 IPPICV_DATE=${1:?IPPICV date is not passed via argument}
 
 files=($(shopt -s nullglob;shopt -s dotglob;echo downloads/ippicv*))
-if [[ ${#files[@]} != 6 ]]; then
+if [[ ${#files[@]} != 5 ]]; then
   echo "ERROR: Please put IPPICV files (for Windows/Mac/Linux platforms) into the downloads directory first."
-  echo "       Found ${#files[@]} files (expected 6)"
+  echo "       Found ${#files[@]} files (expected 5)"
   exit 1
 fi
 


### PR DESCRIPTION
There are no ia32 binaries for macOS anymore.