### PR TITLE
FFmpeg update to n4.4.4 for release 4.8.0

### DIFF
--- a/ffmpeg/download_src.sh
+++ b/ffmpeg/download_src.sh
@@ -21,13 +21,13 @@ mkdir -p ../build
 (
 cd ../build
 # https://github.com/FFmpeg/FFmpeg/releases
-update ffmpeg git://source.ffmpeg.org/ffmpeg.git n4.4.3
+update ffmpeg git://source.ffmpeg.org/ffmpeg.git n4.4.4
 # https://github.com/cisco/openh264/releases
 update openh264 https://github.com/cisco/openh264.git v1.8.0
 # https://chromium.googlesource.com/webm/libvpx.git
-update libvpx https://chromium.googlesource.com/webm/libvpx.git v1.12.0
+update libvpx https://chromium.googlesource.com/webm/libvpx.git v1.13.0
 # https://aomedia.googlesource.com/aom
-update aom https://aomedia.googlesource.com/aom v3.5.0
+update aom https://aomedia.googlesource.com/aom v3.6.1
 )
 
 # Pack all source code / build scripts

--- a/ffmpeg/opencv_ffmpeg.rc
+++ b/ffmpeg/opencv_ffmpeg.rc
@@ -9,8 +9,8 @@
 
 
 VS_VERSION_INFO         VERSIONINFO
-  FILEVERSION           2022,12,0,0
-  PRODUCTVERSION        2022,12,0,0
+  FILEVERSION           2023,06,0,0
+  PRODUCTVERSION        2023,06,0,0
   FILEFLAGSMASK         VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS             1
@@ -26,14 +26,14 @@ BEGIN
     BLOCK "040904E4"
     BEGIN
       VALUE "FileDescription",	"OpenCV FFmpeg wrapper\0"
-      VALUE "FileVersion",	"2022.12.0\0"
+      VALUE "FileVersion",	"2023.06.0\0"
       VALUE "InternalName",	STR(FFMPEG_INTERNAL_NAME) "\0"
 #if 0
       VALUE "LegalCopyright",	"\0"
 #endif
       VALUE "OriginalFilename",	STR(FFMPEG_INTERNAL_NAME) ".dll\0"
       VALUE "ProductName",	"OpenCV FFmpeg wrapper\0"
-      VALUE "ProductVersion",	"2022.12.0\0"
+      VALUE "ProductVersion",	"2023.06.0\0"
 #if 1
       VALUE "Comments",		"http://opencv.org/\0"
 #endif


### PR DESCRIPTION
- FFmpeg version n4.4.4
- OpenH264 version 1.8.0
- libVPX version 1.13.0
- libAOM version 3.6.1