### PR TITLE
The number of uploaded ICV packages has been changed

### DIFF
--- a/build_update.sh
+++ b/build_update.sh
@@ -3,9 +3,9 @@
 IPPICV_DATE=${1:?IPPICV date is not passed via argument}
 
 files=($(shopt -s nullglob;shopt -s dotglob;echo downloads/ippicv*))
-if [[ ${#files[@]} != 5 ]]; then
+if [[ ${#files[@]} != 4 ]]; then
   echo "ERROR: Please put IPPICV files (for Windows/Mac/Linux platforms) into the downloads directory first."
-  echo "       Found ${#files[@]} files (expected 5)"
+  echo "       Found ${#files[@]} files (expected 4)"
   exit 1
 fi
 


### PR DESCRIPTION
4 packages instead of 5 will be uploaded since now because Intel® Integrated Performance Primitives (Intel® IPP) for macOS deprecated in release 2021.9 and will now be discontinued as of Intel IPP release version 2021.10 and later releases.